### PR TITLE
zsh/bash: use $HISTFILE to get history file path

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -1,5 +1,4 @@
 use std::{
-    env,
     error::Error,
     fs::File,
     io::{BufRead, BufReader, Cursor, Read},


### PR DESCRIPTION
Many times, our history file may not be in `~/.bash_history` or `~/.zsh_history`. In this case, we need to read `HISTFILE` to obtain this value, and `HISTFILE` may not be an environment variable, so we need to use a new process to obtain the location of this file.
