### PR TITLE
feat: add subcommand `stats` to fetch current stats directly

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
 use chrono::{Datelike, Local};
-use clap::{arg, command, value_parser, Arg};
+use clap::{arg, command, value_parser, Arg, Command};
 use std::env;
 
 pub struct Cli {
@@ -40,6 +40,10 @@ impl Cli {
                 -s --shell <SHELL> "Specify the target shell / history tool.\nSupported options - zsh, bash, fish, atuin"
                 )
                 .required(false),
+            )
+            .subcommand(
+                Command::new("stats")
+                    .about("Fetch the current stats"),    
             )
             .get_matches();
 


### PR DESCRIPTION
Add subcommand `stats` to fetch current stats directly

Resolve #25