### PR TITLE
Minor change to README - bash cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Supported options for `<shell>` : `zsh`, `bash`, `fish`, `atuin`.
 > In some cases, cmd-wrapped may fail to output correct data (such as [all outputs being 0](https://github.com/YiNNx/cmd-wrapped/issues/3)). This is because it relies on the timestamp track for each command, which sometimes requires configuring specific options extraly:
 >
 > - For Zsh - [EXTENDED_HISTORY](https://zsh.sourceforge.io/Doc/Release/Options.html#History) (oh-my-zsh has it enabled by default)
-> - For Bash - [HISTTIMEFORMAT](https://www.gnu.org/software/bash/manual/bash.html#index-HISTTIMEFORMAT)
+> - For Bash - [HISTTIMEFORMAT](https://www.gnu.org/software/bash/manual/bash.html#index-HISTTIMEFORMAT) (To enable it, run this command: `echo 'HISTTIMEFORMAT="%Y/%m/%d %H:%M:%S "' >> ~/.bashrc`  )
 >
 > **Commands executed before configuring the option won't be recorded with a timestamp and this will affect cmd-wrapped’s stats**.
 


### PR DESCRIPTION
Within the README it mentions that for bash users the `HISTTIMEFORMAT` variable must be set to allow *cmd-wrapped* to start tracking stats.

I made a small addition to the README, which is a command that can be executed by bash users who are running into the '[all outputs being 0](https://github.com/YiNNx/cmd-wrapped/issues/3)' issue; which allows *cmd-wrapped* to start tracking/gathering stats for all of the commands executed **afterwards**.

You can optionally add to the command - so that it also applies the changes made to the *.bashrc* file immediately (rather than having to spawn a new shell):
```bash
echo 'HISTTIMEFORMAT="%Y/%m/%d %H:%M:%S "' >> ~/.bashrc && source ~/.bashrc
``` 